### PR TITLE
Change the names of launch files to be _launch.py

### DIFF
--- a/requirements/core.yaml
+++ b/requirements/core.yaml
@@ -38,16 +38,16 @@ requirements:
             note: Suggests the launch files name `talker_listener`
           - stdin: ros2 launch demo_nodes_cpp talker_listener<tab><tab>
             note: Lists several launch files that start with `talker_listener`
-          - stdin: ros2 launch demo_nodes_cpp talker_listener.launch.p<tab>
-            note: Completes the launch files name `talker_listener.launch.py`
+          - stdin: ros2 launch demo_nodes_cpp talker_listener_launch.p<tab>
+            note: Completes the launch files name `talker_listener_launch.py`
         expect:
-          - stdin: ros2 launch demo_nodes_cpp talker_listener.launch.py
+          - stdin: ros2 launch demo_nodes_cpp talker_listener_launch.py
             note: You eventually get to the full command
       - name: Node discovery
         description: |
           With another node running, use `ros2 node list` to ensure that the expected node is listed. Then stop the node and ensure that the list operation no longer shows the node.
         try:
-          - stdin: ros2 launch demo_nodes_cpp talker_listener.launch.py
+          - stdin: ros2 launch demo_nodes_cpp talker_listener_launch.py
             terminal: 1
           - stdin: ros2 node list
             terminal: 2
@@ -60,7 +60,7 @@ requirements:
         description: |
           With another node running, use `ros2 topic list` to ensure that the expected topics are listed. Then stop the node and ensure that the list operation no longer shows the node's topics.
         try:
-          - stdin: ros2 launch demo_nodes_cpp talker_listener.launch.py
+          - stdin: ros2 launch demo_nodes_cpp talker_listener_launch.py
             terminal: 1
           - stdin: ros2 topic list
             terminal: 2
@@ -149,7 +149,7 @@ requirements:
 
           Loading visualizations into the tree and using the mouse to navigate through the virtual workspace is sufficient for this test.
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
             terminal: 1
           - stdin: rviz2
             terminal: 2
@@ -176,7 +176,7 @@ requirements:
 
           The rqt window should be generally usable and should be able to populate some of the discovered plugins.
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
             terminal: 1
           - stdin: rqt
             terminal: 2

--- a/requirements/features-cli.yaml
+++ b/requirements/features-cli.yaml
@@ -405,7 +405,7 @@ requirements:
     checks:
       - name: Check launch package
         try:
-          - stdin: ros2 launch demo_nodes_cpp talker_listener.launch.py
+          - stdin: ros2 launch demo_nodes_cpp talker_listener_launch.py
         expect:
           - note: You should see something like the following
             stdout: |
@@ -423,9 +423,9 @@ requirements:
 
       - name: Check launch launch file directly
         try:
-          - stdin: curl https://raw.githubusercontent.com/ros2/demos/master/demo_nodes_cpp/launch/topics/talker_listener.launch.py > /tmp/talker_listener.launch.py
+          - stdin: curl https://raw.githubusercontent.com/ros2/demos/master/demo_nodes_cpp/launch/topics/talker_listener_launch.py > /tmp/talker_listener_launch.py
             note: Download a launch file, for example with `curl`.
-          - stdin: ros2 launch /tmp/talker_listener.launch.py
+          - stdin: ros2 launch /tmp/talker_listener_launch.py
         expect:
           - note: You should see something like the following
             stdout: |
@@ -471,7 +471,7 @@ requirements:
     checks:
       - name: Check info
         try:
-          - stdin: ros2 launch demo_nodes_cpp talker_listener.launch.py
+          - stdin: ros2 launch demo_nodes_cpp talker_listener_launch.py
             note: Launch a node
             terminal: 1
           - stdin: ros2 node info /talker
@@ -501,7 +501,7 @@ requirements:
               Action Clients:
       - name: Check list
         try:
-          - stdin: ros2 launch demo_nodes_cpp talker_listener.launch.py
+          - stdin: ros2 launch demo_nodes_cpp talker_listener_launch.py
             note: Launch a node
             terminal: 1
           - stdin: ros2 node list
@@ -777,7 +777,7 @@ requirements:
     checks:
       - name: Check bw
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
             terminal: 1
           - stdin: ros2 topic bw /joint_states
             terminal: 2
@@ -793,7 +793,7 @@ requirements:
               ...
       - name: Check delay
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
             terminal: 1
           - stdin: ros2 topic delay /joint_states
             terminal: 2
@@ -808,7 +808,7 @@ requirements:
               ...
       - name: Check echo
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
             terminal: 1
           - stdin: ros2 topic echo /joint_states
             terminal: 2
@@ -834,7 +834,7 @@ requirements:
               ...
       - name: Check find
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
             terminal: 1
           - stdin: ros2 topic find sensor_msgs/msg/JointState
             terminal: 2
@@ -843,7 +843,7 @@ requirements:
             stdout: /joint_states
       - name: Check hz
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
             terminal: 1
           - stdin: ros2 topic hz /joint_states
             terminal: 2
@@ -858,7 +858,7 @@ requirements:
               ...
       - name: Check info
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
             terminal: 1
           - stdin: ros2 topic info /joint_states
             terminal: 2
@@ -870,7 +870,7 @@ requirements:
               Subscription count: 1
       - name: Check list
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
             terminal: 1
           - stdin: ros2 topic list
             terminal: 2
@@ -887,7 +887,7 @@ requirements:
               /tf_static
       - name: Check type
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
             terminal: 1
           - stdin: ros2 topic type /joint_states
             terminal: 2

--- a/requirements/features-executable-from-links.yaml
+++ b/requirements/features-executable-from-links.yaml
@@ -125,9 +125,9 @@ requirements:
           - note: |
               You will need two machines with ROS 2: one mobile and one stationary.
           - stdin: ros2 run topic_monitor topic_monitor --display
-          - stdin: ros2 launch topic_monitor reliability_demo.launch.py
+          - stdin: ros2 launch topic_monitor reliability_demo_launch.py
             note: |
-              Run the `ros2 launch topic_monitor reliability_demo.launch.py` executable on the stationary machine. This will start two nodes: one publishing in “reliable” mode, and one in “best effort”.
+              Run the `ros2 launch topic_monitor reliability_demo_launch.py` executable on the stationary machine. This will start two nodes: one publishing in “reliable” mode, and one in “best effort”.
           - stdin: ros2 run topic_monitor topic_monitor --display --allowed-latency 5
             note: |
               Start the monitor on a mobile machine such as a laptop. Use `ros2 run topic_monitor topic_monitor --display --allowed-latency 5` to account for any latency that may occur re-sending the reliable messages.

--- a/requirements/features-executable.yaml
+++ b/requirements/features-executable.yaml
@@ -156,9 +156,9 @@ requirements:
       - executable
       - feature
     checks:
-      - name: Check `lifecycle_demo.launch.py`
+      - name: Check `lifecycle_demo_launch.py`
         try:
-          - stdin: ros2 launch lifecycle lifecycle_demo.launch.py
+          - stdin: ros2 launch lifecycle lifecycle_demo_launch.py
   - name: Executables in `tf2_ros`
     labels:
       - executable
@@ -471,9 +471,9 @@ requirements:
       - executable
       - feature
     checks:
-      - name: Check `dummy_robot_bringup.launch.py`
+      - name: Check `dummy_robot_bringup_launch.py`
         try:
-          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup.launch.py
+          - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.py
       - name: Check `dummy_robot_bringup_launch.xml`
         try:
           - stdin: ros2 launch dummy_robot_bringup dummy_robot_bringup_launch.xml

--- a/scripts/executable-features.csv
+++ b/scripts/executable-features.csv
@@ -12,7 +12,7 @@ intra_process_demo,"camera_node, watermark_node, image_view_node"
 composition,linktime_composition
 quality_of_service_demo_cpp,"lifespan, liveliness, deadline"
 quality_of_service_demo_py,"lifespan, liveliness, deadline"
-lifecycle,lifecycle_demo.launch.py
+lifecycle,lifecycle_demo_launch.py
 tf2_ros,"tf2_echo, tf2_monitor, static_transform_publisher"
 ros1_bridge,"dynamic_bridge, ros1_bridge*, both directions"
 examples_rclcpp_*,"minimal_publisher: publisher_lambda, publisher_member_function, publisher_not_composable"
@@ -36,7 +36,7 @@ tlsf_cpp,tlsf_allocator_example
 rttest,rttest_plot
 dummy_map_server,dummy_map_server
 dummy_sensors,"dummy_joint_states, dummy_laser"
-dummy_robot_bringup,"dummy_robot_bringup.launch.py, dummy_robot_bringup_launch.xml, dummy_robot_bringup_launch.yaml "
+dummy_robot_bringup,"dummy_robot_bringup_launch.py, dummy_robot_bringup_launch.xml, dummy_robot_bringup_launch.yaml "
 rviz2,rviz2
 gazebo_ros_pkgs,gazebo --verbose /opt/ros/rolling/share/gazebo_plugins/worlds/gazebo_ros_camera_distortion_barrel_demo.world
 rqt,rqt


### PR DESCRIPTION
This matches the current best practice, which we updated in Iron.

@Yadunund FYI.  I don't think we should regenerate the tests or anything for this, but at least this will be correct for next year.