### PR TITLE
Update the service executables demon_nodes_py test to use async.

### DIFF
--- a/requirements/features-demos-py.yaml
+++ b/requirements/features-demos-py.yaml
@@ -35,9 +35,9 @@ requirements:
             terminal: 1
           - stdin: ros2 run demo_nodes_py add_two_ints_server
             terminal: 2
-      - name: Add two ints sync
+      - name: Add two ints async
         try:
-          - stdin: ros2 run demo_nodes_py add_two_ints_client_sync
+          - stdin: ros2 run demo_nodes_py add_two_ints_client_async
             terminal: 1
           - stdin: ros2 run demo_nodes_py add_two_ints_server
             terminal: 2


### PR DESCRIPTION
There is no '_sync' version, so this must have been a typo for the '_async' version, which does exist.