### PR TITLE
Remove windows tests for realtime tools

### DIFF
--- a/requirements/features-executable.yaml
+++ b/requirements/features-executable.yaml
@@ -435,6 +435,7 @@ requirements:
     labels:
       - executable
       - feature
+      - linux
     checks:
       - name: Check `tlsf_allocator_example`
         try:
@@ -443,6 +444,7 @@ requirements:
     labels:
       - executable
       - feature
+      - linux
     checks:
       - name: Check `rttest_plot`
         try:


### PR DESCRIPTION
This PR adds `linux` labels to realtime_tools executables.
The test case generator will not include these along with windows given the existing filter https://github.com/audrow/yatm/blob/5528cb122afabcc110d31f76fcaa331a678718f7/test-case.config.yaml#L60-L67