### PR TITLE
fix a wrong command

### DIFF
--- a/requirements/features-cli.yaml
+++ b/requirements/features-cli.yaml
@@ -31,7 +31,7 @@ requirements:
         try:
           - stdin: ros2 run examples_rclcpp_minimal_action_server action_server_member_functions
             terminal: 1
-          - stdin: ros2 action send_goal /fibonacci example_interfaces/action/Fibonacci order:\ 2\
+          - stdin: ros2 action send_goal /fibonacci example_interfaces/action/Fibonacci order:\ 2
             terminal: 2
         expect:
           - stdout: |


### PR DESCRIPTION
To fix

https://github.com/osrf/ros2_test_cases/issues/485

```
# User input in terminal 1
ros2 action send_goal /fibonacci example_interfaces/action/Fibonacci order:\ 2            terminal: 2
```


