### PR TITLE
Rqt

### DIFF
--- a/requirements/features-executable.yaml
+++ b/requirements/features-executable.yaml
@@ -507,7 +507,7 @@ requirements:
     checks:
       - name: Check `rqt`
         try:
-          - stdin: ros2 run rqt rqt
+          - stdin: rqt
   - name: Executables in `rosbag2`
     labels:
       - executable


### PR DESCRIPTION
Given [existing problems](https://github.com/osrf/ros2_test_cases/issues/688#issuecomment-1536020364) with rqt executable, have users start rqt without ros2 run.
