### PR TITLE
Modifies the console input to test out rqt

### DIFF
--- a/requirements/features-executable.yaml
+++ b/requirements/features-executable.yaml
@@ -476,7 +476,7 @@ requirements:
     checks:
       - name: Check `rqt`
         try:
-          - stdin: ros2 run rqt rqt
+          - stdin: rqt
   - name: Executables in `rosbag2`
     labels:
       - executable


### PR DESCRIPTION
This PR modifies the console input to run `rqt` according to the discussions made https://github.com/ros-visualization/rqt/issues/270 and https://github.com/ros-visualization/rqt/pull/293.

At the moment, the only command that works in linux and windows in order to use rqt is `rqt`, we believe it makes sense to just set that command as the default executable. Taking into account that on windows the command `ros2 run rqt_gui rqt_gui` does not work due to it being a `.py` file instead of a `.exe` file, it makes sense to suggest the only command that works on both platforms.