### PR TITLE
Removes gazebo_ros_pkgs for testing in Windows

### DIFF
--- a/requirements/features-executable.yaml
+++ b/requirements/features-executable.yaml
@@ -461,6 +461,7 @@ requirements:
     labels:
       - executable
       - feature
+      - linux
     checks:
       - name: >-
           Check `gazebo --verbose


### PR DESCRIPTION
This PR addresses an item from https://github.com/audrow/yatm/issues/366 according to this [discussion](https://github.com/osrf/ros2_test_cases/issues/656#issuecomment-1543388664).