### PR TITLE
Updates ROS 1 Bridge test cases and instructions

### DIFF
--- a/requirements/features-executable-from-links.yaml
+++ b/requirements/features-executable-from-links.yaml
@@ -158,6 +158,7 @@ requirements:
     labels:
       - executable
       - feature
+      - linux
       - ros1_bridge
     links:
       - name: Reference URL


### PR DESCRIPTION
This PR addresses an item from https://github.com/audrow/yatm/issues/366 according to this [discussion](https://github.com/osrf/ros2_test_cases/issues/790#issuecomment-1552994338).

The information missing on the instructions from the reference link is how to build `ROS1` from source since `ros1_bridge` does not work with the `ROS1` debians from Ubuntu packages for Jammy. What should we do here @Yadunund? Maybe create custom instructions like the ones from [here](https://github.com/osrf/ros2_test_cases/issues/793#issuecomment-1547188641)?