### PR TITLE
Filter redirects in docs.ros.org sitemap

### DIFF
--- a/test-case.config.yaml
+++ b/test-case.config.yaml
@@ -37,8 +37,6 @@ sets:
         labels:
           - ignition
       - isMatch: false
-        name: Custom ROS2 Interfaces.rst
-      - isMatch: false
         name: Recording A Bag From Your Own Node Python
     dimensions:
       dds:

--- a/test-case.config.yaml
+++ b/test-case.config.yaml
@@ -16,8 +16,11 @@ sets:
         labels:
           - launch
       - isMatch: false
+        name: Webots
         labels:
           - webots
+      - isMatch: false
+        name: Deploying ROS 2 on IBM Cloud
       - isMatch: false
         name: Security on Two
       - isMatch: false
@@ -28,6 +31,15 @@ sets:
         name: Releasing a ROS 2 package with bloom
       - isMatch: false
         name: Rosbag with ROS1 Bridge
+      # Ignore links which are redirects.
+      - isMatch: false
+        name: Ignition
+        labels:
+          - ignition
+      - isMatch: false
+        name: Custom ROS2 Interfaces.rst
+      - isMatch: false
+        name: Recording A Bag From Your Own Node Python
     dimensions:
       dds:
         - fastdds


### PR DESCRIPTION
The sitemap for docs.ros.org includes links that are directed to newer pages. But yatm cannot differentiate between new and old links (primarily because the sitemap.xml makes no differentiation). Instead we deal with these duplicates by filtering them out explicitly in the test cases config file.

Also filtered out the IBM cloud tutorial since it's community contributed and not straightforward to complete.